### PR TITLE
HY-4412 change version so first release can be 1.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'font_face_observer'
-version: 1.0.0
+version: 0.9.0
 description: Font load events, simple, small and efficient. Dart port of https://github.com/bramstein/fontfaceobserver
 author: Rob Becker <rob.becker@workiva.com>
 homepage: https://github.com/Workiva/font_face_observer


### PR DESCRIPTION
# Problem
We want the first tagged release to be 1.0

# Solution
Subtract from the current 1.0 version so our automated tools can increment to 1.0.0

# +10
 - [x] CI passes