### PR TITLE
HY-4282 Release font_face_observer 1.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'font_face_observer'
-version: 0.9.0
+version: 1.0.0
 description: Font load events, simple, small and efficient. Dart port of https://github.com/bramstein/fontfaceobserver
 author: Rob Becker <rob.becker@workiva.com>
 homepage: https://github.com/Workiva/font_face_observer


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/HY-4282

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 

======= font_face_observer 1.0.0 items =======

 HY-4412  - change version so first release can be 1.0  - https://github.com/Workiva/font_face_observer/pull/3
Update readme  - https://github.com/Workiva/font_face_observer/pull/2

 HY-4308  - Initialize Font Face Observer repo  - https://github.com/Workiva/font_face_observer/pull/1

======= end =======

Diff Between Last Tag and Proposed Release: N/A
Diff Between Last Tag and New Tag: N/A

