### PR TITLE
HY-4413 Release font_face_observer 1.0.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'font_face_observer'
-version: 1.0.0
+version: 1.0.1
 description: Font load events, simple, small and efficient. Dart port of https://github.com/bramstein/fontfaceobserver
 author: Rob Becker <rob.becker@workiva.com>
 homepage: https://github.com/Workiva/font_face_observer


### PR DESCRIPTION

Pulls Included in Release:
* [HY-4418 Forgot quotes around font family in check() call](https://github.com/Workiva/font_face_observer/pull/5)


Requested by: @charliekump-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/font_face_observer/compare/1.0.0...version-bump-font_face_observer-1-0-1
Diff Between Last Tag and New Tag: https://github.com/Workiva/font_face_observer/compare/1.0.0...1.0.1