### PR TITLE
RMCONS-5518 Consume smithy-runner 3.5.5

### DIFF
--- a/smithy.yml
+++ b/smithy.yml
@@ -1,5 +1,6 @@
 project: static
 language: dart
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner:112206
 
 runner_image: drydock-prod.workiva.org/workiva/smithy-runner-dart:91483
 


### PR DESCRIPTION
In order to keep builds deterministic, and reduce the risk of future build failure, please pin your smithy runner to the currently defaulted runner.
For more information please see the email 'Smithy Runner Recommendation' or reach out to Travis Reed in hipchat.


Requested by: @travisreed-wf