### PR TITLE
HY-4679 fix the stuck font loading check

### DIFF
--- a/lib/font_face_observer.dart
+++ b/lib/font_face_observer.dart
@@ -197,7 +197,7 @@ class FontFaceObserver {
     SpanElement dummy = document.getElementById(_key);
     if (dummy == null) {
       dummy = new SpanElement()
-        ..className = '$fontFaceObserverTempClassname  _ffo_dummy'
+        ..className = '$fontFaceObserverTempClassname _ffo_dummy'
         ..id = _key
         ..setAttribute('style', 'font-family: "${family}"; visibility: hidden;')
         ..text = testString;


### PR DESCRIPTION
# Problem
It's possible for the `document.fonts.check` call to return false resulting in never detecting that a font is loaded.

# Solution
Move adding the dummy element up into the check call.
Since browsers may not load a font until it is actually used in the DOM, we add this span to trigger the browser to load the font when used.

# +10 Instructions
 - [x] Wire it up into graph_app and switch docs while fonts are loading, then switch back. @tomconnell-wf  knows.