### PR TITLE
HY-4693 Release font_face_observer 2.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'font_face_observer'
-version: 1.1.1
+version: 2.0.0
 description: Font load events, simple, small and efficient. Dart port of https://github.com/bramstein/fontfaceobserver
 author: Rob Becker <rob.becker@workiva.com>
 homepage: https://github.com/Workiva/font_face_observer


### PR DESCRIPTION

Pulls Included in Release:
* [HY-4737 Fix unloading, refactor and cleanup](https://github.com/Workiva/font_face_observer/pull/15)


Requested by: @seanburke-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/font_face_observer/compare/1.1.1...version-bump-font_face_observer-2-0-0
Diff Between Last Tag and New Tag: https://github.com/Workiva/font_face_observer/compare/1.1.1...2.0.0