### PR TITLE
HY-4744 Release font_face_observer 2.0.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'font_face_observer'
-version: 2.0.0
+version: 2.0.1
 description: Font load events, simple, small and efficient. Dart port of https://github.com/bramstein/fontfaceobserver
 author: Rob Becker <rob.becker@workiva.com>
 homepage: https://github.com/Workiva/font_face_observer


### PR DESCRIPTION

Pulls Included in Release:
* [HY-4981 Memory audit](https://github.com/Workiva/font_face_observer/pull/17)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/font_face_observer/compare/2.0.0...version-bump-font_face_observer-2-0-1
Diff Between Last Tag and New Tag: https://github.com/Workiva/font_face_observer/compare/2.0.0...2.0.1