### PR TITLE
HY-5112 Release font_face_observer 2.0.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'font_face_observer'
-version: 2.0.1
+version: 2.0.2
 description: Font load events, simple, small and efficient. Dart port of https://github.com/bramstein/fontfaceobserver
 author: Rob Becker <rob.becker@workiva.com>
 homepage: https://github.com/Workiva/font_face_observer


### PR DESCRIPTION

Pulls Included in Release:
* [HY-5259 add null checks](https://github.com/Workiva/font_face_observer/pull/19)


Requested by: @patkujawa-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/font_face_observer/compare/2.0.1...Workiva:release_font_face_observer_2_0_2
Diff Between Last Tag and New Tag: https://github.com/Workiva/font_face_observer/compare/2.0.1...2.0.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5432637706469376/logs/)