### PR TITLE
Adds license info from the original JS font face observer & W3C

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -38,8 +38,9 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 This software or document includes material copied from or derived from 
-CSS Font Loading Module Level 3 Copyright © 2017 W3C® 
-(MIT, ERCIM, Keio, Beihang) which is licensed under the following terms:
+CSS Font Loading Module Level 3 (https://drafts.csswg.org/css-font-loading/)
+Copyright © 2017 W3C® (MIT, ERCIM, Keio, Beihang) which is licensed 
+under the following terms:
 
 By obtaining and/or copying this work, you (the licensee) agree that you 
 have read, understood, and will comply with the following terms and conditions.

--- a/NOTICE
+++ b/NOTICE
@@ -38,8 +38,9 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 This software or document includes material copied from or derived from 
-CSS Font Loading Module Level 3 Copyright © 2017 W3C® 
-(MIT, ERCIM, Keio, Beihang) which is licensed under the following terms:
+CSS Font Loading Module Level 3 (https://drafts.csswg.org/css-font-loading/)
+Copyright © 2017 W3C® (MIT, ERCIM, Keio, Beihang) which is licensed 
+under the following terms:
 
 By obtaining and/or copying this work, you (the licensee) agree that you 
 have read, understood, and will comply with the following terms and conditions.

--- a/lib/data_uri.dart
+++ b/lib/data_uri.dart
@@ -39,8 +39,9 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 This software or document includes material copied from or derived from 
-CSS Font Loading Module Level 3 Copyright © 2017 W3C® 
-(MIT, ERCIM, Keio, Beihang) which is licensed under the following terms:
+CSS Font Loading Module Level 3 (https://drafts.csswg.org/css-font-loading/)
+Copyright © 2017 W3C® (MIT, ERCIM, Keio, Beihang) which is licensed 
+under the following terms:
 
 By obtaining and/or copying this work, you (the licensee) agree that you 
 have read, understood, and will comply with the following terms and conditions.

--- a/lib/font_face_observer.dart
+++ b/lib/font_face_observer.dart
@@ -39,8 +39,9 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 This software or document includes material copied from or derived from 
-CSS Font Loading Module Level 3 Copyright © 2017 W3C® 
-(MIT, ERCIM, Keio, Beihang) which is licensed under the following terms:
+CSS Font Loading Module Level 3 (https://drafts.csswg.org/css-font-loading/)
+Copyright © 2017 W3C® (MIT, ERCIM, Keio, Beihang) which is licensed 
+under the following terms:
 
 By obtaining and/or copying this work, you (the licensee) agree that you 
 have read, understood, and will comply with the following terms and conditions.

--- a/lib/src/adobe_blank.dart
+++ b/lib/src/adobe_blank.dart
@@ -39,8 +39,9 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 This software or document includes material copied from or derived from 
-CSS Font Loading Module Level 3 Copyright © 2017 W3C® 
-(MIT, ERCIM, Keio, Beihang) which is licensed under the following terms:
+CSS Font Loading Module Level 3 (https://drafts.csswg.org/css-font-loading/)
+Copyright © 2017 W3C® (MIT, ERCIM, Keio, Beihang) which is licensed 
+under the following terms:
 
 By obtaining and/or copying this work, you (the licensee) agree that you 
 have read, understood, and will comply with the following terms and conditions.

--- a/lib/src/ruler.dart
+++ b/lib/src/ruler.dart
@@ -39,8 +39,9 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 This software or document includes material copied from or derived from 
-CSS Font Loading Module Level 3 Copyright © 2017 W3C® 
-(MIT, ERCIM, Keio, Beihang) which is licensed under the following terms:
+CSS Font Loading Module Level 3 (https://drafts.csswg.org/css-font-loading/)
+Copyright © 2017 W3C® (MIT, ERCIM, Keio, Beihang) which is licensed 
+under the following terms:
 
 By obtaining and/or copying this work, you (the licensee) agree that you 
 have read, understood, and will comply with the following terms and conditions.

--- a/lib/support.dart
+++ b/lib/support.dart
@@ -39,8 +39,9 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 This software or document includes material copied from or derived from 
-CSS Font Loading Module Level 3 Copyright © 2017 W3C® 
-(MIT, ERCIM, Keio, Beihang) which is licensed under the following terms:
+CSS Font Loading Module Level 3 (https://drafts.csswg.org/css-font-loading/)
+Copyright © 2017 W3C® (MIT, ERCIM, Keio, Beihang) which is licensed 
+under the following terms:
 
 By obtaining and/or copying this work, you (the licensee) agree that you 
 have read, understood, and will comply with the following terms and conditions.

--- a/test/data_uri_test.dart
+++ b/test/data_uri_test.dart
@@ -39,8 +39,9 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 This software or document includes material copied from or derived from 
-CSS Font Loading Module Level 3 Copyright © 2017 W3C® 
-(MIT, ERCIM, Keio, Beihang) which is licensed under the following terms:
+CSS Font Loading Module Level 3 (https://drafts.csswg.org/css-font-loading/)
+Copyright © 2017 W3C® (MIT, ERCIM, Keio, Beihang) which is licensed 
+under the following terms:
 
 By obtaining and/or copying this work, you (the licensee) agree that you 
 have read, understood, and will comply with the following terms and conditions.

--- a/test/font_face_observer_test.dart
+++ b/test/font_face_observer_test.dart
@@ -39,8 +39,9 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 This software or document includes material copied from or derived from 
-CSS Font Loading Module Level 3 Copyright © 2017 W3C® 
-(MIT, ERCIM, Keio, Beihang) which is licensed under the following terms:
+CSS Font Loading Module Level 3 (https://drafts.csswg.org/css-font-loading/)
+Copyright © 2017 W3C® (MIT, ERCIM, Keio, Beihang) which is licensed 
+under the following terms:
 
 By obtaining and/or copying this work, you (the licensee) agree that you 
 have read, understood, and will comply with the following terms and conditions.

--- a/test/main.dart
+++ b/test/main.dart
@@ -39,8 +39,9 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 This software or document includes material copied from or derived from 
-CSS Font Loading Module Level 3 Copyright © 2017 W3C® 
-(MIT, ERCIM, Keio, Beihang) which is licensed under the following terms:
+CSS Font Loading Module Level 3 (https://drafts.csswg.org/css-font-loading/)
+Copyright © 2017 W3C® (MIT, ERCIM, Keio, Beihang) which is licensed 
+under the following terms:
 
 By obtaining and/or copying this work, you (the licensee) agree that you 
 have read, understood, and will comply with the following terms and conditions.

--- a/test/ruler_test.dart
+++ b/test/ruler_test.dart
@@ -39,8 +39,9 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 This software or document includes material copied from or derived from 
-CSS Font Loading Module Level 3 Copyright © 2017 W3C® 
-(MIT, ERCIM, Keio, Beihang) which is licensed under the following terms:
+CSS Font Loading Module Level 3 (https://drafts.csswg.org/css-font-loading/)
+Copyright © 2017 W3C® (MIT, ERCIM, Keio, Beihang) which is licensed 
+under the following terms:
 
 By obtaining and/or copying this work, you (the licensee) agree that you 
 have read, understood, and will comply with the following terms and conditions.

--- a/test/unload.dart
+++ b/test/unload.dart
@@ -39,8 +39,9 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 This software or document includes material copied from or derived from 
-CSS Font Loading Module Level 3 Copyright © 2017 W3C® 
-(MIT, ERCIM, Keio, Beihang) which is licensed under the following terms:
+CSS Font Loading Module Level 3 (https://drafts.csswg.org/css-font-loading/)
+Copyright © 2017 W3C® (MIT, ERCIM, Keio, Beihang) which is licensed 
+under the following terms:
 
 By obtaining and/or copying this work, you (the licensee) agree that you 
 have read, understood, and will comply with the following terms and conditions.


### PR DESCRIPTION
Adds license info from the original JS font face observer & W3C spec page for the Font Face API