### PR TITLE
HY-5323 Release font_face_observer 2.0.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'font_face_observer'
-version: 2.0.3
+version: 2.0.4
 description: Font load events, simple, small and efficient. Dart port of https://github.com/bramstein/fontfaceobserver
 author: Rob Becker <rob.becker@workiva.com>
 homepage: https://github.com/Workiva/font_face_observer


### PR DESCRIPTION

Pulls Included in Release:
* [HY-5546 Add license to more files](https://github.com/Workiva/font_face_observer/pull/23)
* [Revert "Update license to include originals from other sources"](https://github.com/Workiva/font_face_observer/pull/24)
* [Adds license info from the original JS font face observer & W3C](https://github.com/Workiva/font_face_observer/pull/25)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/font_face_observer/compare/2.0.3...Workiva:release_font_face_observer_2_0_4
Diff Between Last Tag and New Tag: https://github.com/Workiva/font_face_observer/compare/2.0.3...2.0.4

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5432637706469376/logs/)