### PR TITLE
Remove semver audit dependency, publish publicly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ dart:
   - 1.24.2
 addons:
   chrome: stable
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
 script:
   - pub get
   - pub run dart_dev format --check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: dart
 dart:
   - 1.24.2
+addons:
+  chrome: stable
 script:
   - pub get
   - pub run dart_dev format --check
   - pub run dart_dev analyze
   - pub publish --dry-run
-  - pub run dart_dev test -p content-shell
+  - pub run dart_dev test -p chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: dart
+dart:
+  - 1.24.2
+script:
+  - pub get
+  - pub run dart_dev format --check
+  - pub run dart_dev analyze
+  - pub publish --dry-run
+  - pub run dart_dev test -p content-shell

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,6 @@ version: 2.0.4
 description: Font load events, simple, small and efficient. Dart port of https://github.com/bramstein/fontfaceobserver
 author: Rob Becker <rob.becker@workiva.com>
 homepage: https://github.com/Workiva/font_face_observer
-publish_to: https://pub.workiva.org
 
 environment:
   sdk: '>=1.22.1 <2.0.0'
@@ -15,11 +14,6 @@ dev_dependencies:
   dart_style: ">=1.0.0 < 2.0.0"
   dartdoc: ">=0.12.0 < 2.0.0"
   test: ">=0.12.0 < 2.0.0"
-  semver_audit:
-    hosted:
-      name: semver_audit
-      url: https://pub.workiva.org
-    version: ^1.1.1
 
 transformers:
 - $dart2js:

--- a/smithy.yml
+++ b/smithy.yml
@@ -13,7 +13,6 @@ script:
   - pub run dart_dev format --check
   - xvfb-run -s '-screen 0 1024x768x24' pub run dart_dev test -p content-shell
   - xvfb-run -s '-screen 0 1024x768x24' pub run dart_dev coverage --no-html
-  - pub run semver_audit report --repo Workiva/font_face_observer
   
   # Create docs
   - pub run dart_dev docs --no-open


### PR DESCRIPTION
# Problem
semver_audit is a workiva internal package and can't be installed externally and there's no travis.yml.

# Solution
 - Remove it from pubspec.yaml. 
 - Add a .travis.yml
 - update the publish_to to be correct.