### PR TITLE
HY-5566 Release font_face_observer 2.0.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'font_face_observer'
-version: 2.0.5
+version: 2.0.6
 description: Font load events, simple, small and efficient. Dart port of https://github.com/bramstein/fontfaceobserver
 author: Rob Becker <rob.becker@workiva.com>
 homepage: https://github.com/Workiva/font_face_observer


### PR DESCRIPTION

Pulls Included in Release:
* [Add CHANGELOG](https://github.com/Workiva/font_face_observer/pull/29)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/font_face_observer/compare/2.0.5...Workiva:release_font_face_observer_2_0_6
Diff Between Last Tag and New Tag: https://github.com/Workiva/font_face_observer/compare/2.0.5...2.0.6

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5432637706469376/logs/)