### PR TITLE
BUILDTOOLS-2329: Update Dockerfile to mirror smithy.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:194606 as build
+
+# Build Environment Vars
+ARG BUILD_ID
+ARG BUILD_NUMBER
+ARG BUILD_URL
+ARG GIT_COMMIT
+ARG GIT_BRANCH
+ARG GIT_TAG
+ARG GIT_COMMIT_RANGE
+ARG GIT_HEAD_URL
+ARG GIT_MERGE_HEAD
+ARG GIT_MERGE_BRANCH
+WORKDIR /build/
+ADD . /build/
+ENV CODECOV_TOKEN='bQ4MgjJ0G2Y73v8JNX6L7yMK9679nbYB'
+RUN echo "Starting the script sections" && \
+		pub get --packages-dir && \
+		pub publish --dry-run && \
+		pub run dart_dev analyze && \
+		pub run dart_dev format --check && \
+		xvfb-run -s '-screen 0 1024x768x24' pub run dart_dev test --web-compiler=dartdevc -p content-shell && \
+		xvfb-run -s '-screen 0 1024x768x24' pub run dart_dev coverage --no-html && \
+		pub run dart_dev docs --no-open && \
+		tar czvf api.tar.gz -C doc/api . && \
+		pub build test && \
+		./tool/stage_for_cdn.sh && \
+		tar -hcf build.tar.gz build/test/ && \
+		tar czvf font_face_observer.pub.tgz LICENSE README.md pubspec.yaml lib/ && \
+		./tool/codecov.sh && \
+		echo "Script sections completed"
+ARG BUILD_ARTIFACTS_WEB_BUILD=/build/build.tar.gz
+ARG BUILD_ARTIFACTS_DOCUMENTATION=/build/api.tar.gz
+ARG BUILD_ARTIFACTS_DART-DEPENDENCIES=/build/pubspec.lock
+ARG BUILD_ARTIFACTS_PUB=/build/font_face_observer.pub.tgz
+FROM scratch


### PR DESCRIPTION

## Overview
In order to improve build isolation, reduce costs, reduce support burden, remove black magic, and improve local consistency, we are migrating away from smithy.yaml and existing Smithy infrastructure to Dockerfile builds supported by off the shelf AWS resources.

Reviewing and merging this PR is the first step in that process; this PR simply copies the contents of your smithy.yaml into a more explicit Dockerfile. 
In order to begin running Dockerfile builds you will need to enable Dockerfile builds from your [repo configuration page in Smithy](https://ci.webfilings.com/Workiva/font_face_observer).
Once you have enabled Dockerfile builds for your repo, rebuilding the PR build in smithy will trigger the newly enabled Dockefile build.

### Expectations
With only a [couple of exceptions](https://dev.workiva.net/docs/productivity-engineering-platform/workiva-build/migration-from-smithy#differences-in-behavior-between-workiva-build-and-smithy-builds) the behavior of this new Dockerfile should match the existing behavior in your smithy.yaml
Therefore, our expectations are for you to merge this PR as soon as possible. If for any reason you discover a problem post merge, you can disable the new builds and re-enable smithy.yaml builds in your [repo configuration page in Smithy](https://ci.webfilings.com/Workiva/font_face_observer)

### Support/Questions
The migration to Dockerfile builds is our top priority, so please reach out to us if you have any questions, comments, or concerns during this process. Non-urgent questions should go into [Confluence Questions](https://wiki.atl.workiva.net/questions) and urgent support can be requested in the Support: Build Tools Hipchat Room 

### More Info
Information about the migration to dockerfile can be found [here](https://dev.workiva.net/docs/productivity-engineering-platform/workiva-build/migration-from-smithy#differences-in-behavior-between-workiva-build-and-smithy-builds)
A user guide for Dockerfile builds can be found [here](https://dev.workiva.net/docs/productivity-engineering-platform/workiva-build/user-guide)


@robbecker-wf