### PR TITLE
AF-1484: af_2018_abide_for_all

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ RUN echo "Starting the script sections" && \
 	pub get --packages-dir && \
 	pub publish --dry-run && \
 	pub run dart_dev analyze && \
+	pub run abide && \
+	pub run dependency_validator -i abide,analyzer,browser,coverage,dart_dev,dart_style,dartdoc,semver_audit && \
+	pub run semver_audit report --repo Workiva/font_face_observer && \
 	pub run dart_dev format --check && \
 	xvfb-run -s '-screen 0 1024x768x24' pub run dart_dev test --web-compiler=dartdevc -p dartium && \
 	xvfb-run -s '-screen 0 1024x768x24' pub run dart_dev coverage --no-html && \

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,12 +12,23 @@ web:
     debug: dartdevc
 
 dev_dependencies:
+  abide:
+    hosted:
+      name: abide
+      url: https://pub.workiva.org
+    version: ^1.4.1
   analyzer: ">= 0.29.0 <= 0.30.0+4"
   browser: ^0.10.0
   coverage: ">=0.7.0 < 2.0.0"
   dart_dev: ^1.7.8
   dart_style: ">=1.0.0 < 2.0.0"
   dartdoc: ">=0.12.0 <= 0.15.1"
+  dependency_validator: ^1.1.1
+  semver_audit:
+    hosted:
+      name: semver_audit
+      url: https://pub.workiva.org
+    version: ^1.4.2
   test: ">=0.12.0 < 2.0.0"
 
 transformers:


### PR DESCRIPTION
## Purpose

The following pull request has been auto-generated by App Frameworks to help us roll out the adoption of tooling intended to propagate standards and best practices. This tooling will allow our engineers to more easily keep codebases updated with the latest organization standards.

## Changes

The following changes have been made:
* `analysis_options.yaml` has been updated with the latest required lints.
* Abide has been added to your CI build script.
## Questions

**Please do not merge this pr as we need to add some additional changes that could not be automated.**

If you have any questions, please reach out to us in the “Support: H5 / Dart” Hipchat room.

### Abide rollout checklist
- [ ] analysis_options are updated
- [ ] analysis passes - which likely require fixing lints, warnings and errors
- [ ] pubspec.yaml has the following installed under ```dev_dependencies``` and add if not present:
         - abide
         - dependency_validator
         - semver_audit
- [ ] Docker/Smithy/Task-Runner has the following and add if not present:
         - `pub run abide`
         - `pub run dependency_validator` (this will likely need to be configured to exclude some things, for example: ```pub run dependency_validator -x example/tracing/messaging_middleware,example/tracing/messaging_http_middleware -i coverage,dart_style,dartdoc,semver_audit```)
         - `pub run semver_audit` (which will need to look like this: ```pub run semver_audit report --repo Workiva/app_intelligence_dart``` but configured properly)
- [ ] check that the repo abides
- [ ] check that abide was run in CI

@dustinlessard-wf @sebastianmalysa-wf