### PR TITLE
HY-5774 Release font_face_observer 2.0.9

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'font_face_observer'
-version: 2.0.8
+version: 2.0.9
 description: Font load events, simple, small and efficient. Dart port of https://github.com/bramstein/fontfaceobserver
 author: Rob Becker <rob.becker@workiva.com>
 homepage: https://github.com/Workiva/font_face_observer


### PR DESCRIPTION

Pulls Included in Release:
* [BUILDTOOLS-2329: Update Dockerfile to mirror smithy.yaml](https://github.com/Workiva/font_face_observer/pull/37)
* [AF-1837 dart 1 and dart2 compat](https://github.com/Workiva/font_face_observer/pull/38)
* [af_2018_abide_rollout](https://github.com/Workiva/font_face_observer/pull/39)
* [HY-5924 set dartium expiration](https://github.com/Workiva/font_face_observer/pull/42)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/font_face_observer/compare/2.0.8...Workiva:release_font_face_observer_2_0_9
Diff Between Last Tag and New Tag: https://github.com/Workiva/font_face_observer/compare/2.0.8...2.0.9

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5432637706469376/logs/)