### PR TITLE
Use = instead of : for default values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: dart
 sudo: required
 dart:
-  - 1.24.3
-  - dev
+  - stable
 dart_task:
   - test: --platform vm
   - test: --platform chrome

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,31 @@
-# 2.0.7
+## 2.0.10
+* [x] [#46](https://github.com/Workiva/font_face_observer/pull/46) Use = instead of : for default values
+
+## 2.0.9
+
+* [x] [#37](https://github.com/Workiva/font_face_observer/pull/39) BUILDTOOLS-2329: Update Dockerfile to mirror smithy.yaml
+* [x] [#38](https://github.com/Workiva/font_face_observer/pull/38) AF-1837 dart 1 and dart2 compat
+* [x] [#39](https://github.com/Workiva/font_face_observer/pull/39) af_2018_abide_rollout
+* [x] [#42](https://github.com/Workiva/font_face_observer/pull/42) HY-5924 set dartium expiration
+
+## 2.0.8
+
+* [x] strongest lint rules, fixed all lint and dart 2 warnings https://github.com/Workiva/font_face_observer/pull/33
+
+## 2.0.7
+
 * [x] Added more analysis option lint rules
 * [x] default to DDC for running tests
 
-# 2.0.6
+## 2.0.6
+
 * [x] #29 Add CHANGELOG.md
 
-# 2.0.5
-This **patch** release includes the following changes:
-## Miscellaneous
+## 2.0.5
+
 * [x] #27 Remove semver audit dependency, publish publicly
 
-# 2.0.4
-This **patch** release includes the following changes:
-## Miscellaneous
+## 2.0.4
+
 * [x] #23 HY-5546 Add license to more files
-	* HY-5546 Add license to more files
 * [x] #25 Adds license info from the original JS font face observer & W3C

--- a/example/main.dart
+++ b/example/main.dart
@@ -78,9 +78,9 @@ class _FontConfig {
   _FontConfig(
       {this.family,
       this.url,
-      this.testString: _successMessage,
-      this.expectLoad: true,
-      this.useSimulatedLoadEvents: false});
+      this.testString = _successMessage,
+      this.expectLoad = true,
+      this.useSimulatedLoadEvents = false});
 }
 
 final List<_FontConfig> _fonts = <_FontConfig>[]

--- a/example/unload.dart
+++ b/example/unload.dart
@@ -91,8 +91,8 @@ class _FontConfig {
   _FontConfig(
       {this.family,
       this.url,
-      this.useSimulatedLoadEvents: false,
-      this.group: FontFaceObserver.defaultGroup});
+      this.useSimulatedLoadEvents = false,
+      this.group = FontFaceObserver.defaultGroup});
   String key;
 }
 

--- a/lib/data_uri.dart
+++ b/lib/data_uri.dart
@@ -101,10 +101,10 @@ class DataUri {
   /// Construct a new DataUri. Assume that [data] is base64 encoded unless
   /// [isDataBase64Encoded] is passed in as false
   DataUri(
-      {this.mimeType: 'application/octet-stream',
+      {this.mimeType = 'application/octet-stream',
       this.encoding,
       this.data,
-      this.isDataBase64Encoded: true});
+      this.isDataBase64Encoded = true});
 
   @override
   String toString() =>

--- a/lib/font_face_observer.dart
+++ b/lib/font_face_observer.dart
@@ -82,7 +82,7 @@ class FontLoadResult {
 
   // ignoring since the constructor is so simple, docs are just redundant
   // ignore: public_member_api_docs
-  FontLoadResult({this.isLoaded: true, this.didTimeout: false});
+  FontLoadResult({this.isLoaded = true, this.didTimeout = false});
 
   @override
   String toString() =>
@@ -216,13 +216,13 @@ class FontFaceObserver {
   /// ```
 
   FontFaceObserver(this.family,
-      {this.style: _normal,
-      this.weight: _normal,
-      this.stretch: _normal,
-      String testString: _defaultTestString,
-      this.timeout: _defaultTimeout,
-      this.useSimulatedLoadEvents: false,
-      String group: defaultGroup}) {
+      {this.style = _normal,
+      this.weight = _normal,
+      this.stretch = _normal,
+      String testString = _defaultTestString,
+      this.timeout = _defaultTimeout,
+      this.useSimulatedLoadEvents = false,
+      String group = defaultGroup}) {
     if (key != adobeBlankKey && !_loadedFonts.containsKey(adobeBlankKey)) {
       _adobeBlankLoadedFuture = _loadAdobeBlank();
     }
@@ -467,7 +467,7 @@ class FontFaceObserver {
 
   /// Generates the CSS style string to be used when detecting a font load
   /// for a given [family] at a certain [cssSize] (default 100px)
-  String _getStyle(String family, {String cssSize: '100px'}) {
+  String _getStyle(String family, {String cssSize = '100px'}) {
     final String _stretch = supportsStretch ? stretch : '';
     return '$style $weight $_stretch $cssSize $family';
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   dart2_constant: ^1.0.0
 
 dev_dependencies:
-  build_runner: ">=0.6.0<1.0.0"
-  build_test: ">=0.9.0<1.0.0"
-  build_web_compilers: ">=0.2.0<1.0.0"
+  build_runner: ">=0.6.0 <2.0.0"
+  build_test: ">=0.9.0 <1.0.0"
+  build_web_compilers: ">=0.2.0 <3.0.0"
   test: ">=0.12.30 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   dart2_constant: ^1.0.0
 
 dev_dependencies:
-  build_runner: ">=0.6.0 <2.0.0"
-  build_test: ">=0.9.0 <1.0.0"
-  build_web_compilers: ">=0.2.0 <3.0.0"
+  build_runner: ">=0.6.0<1.0.0"
+  build_test: ">=0.9.0<1.0.0"
+  build_web_compilers: ">=0.2.0<1.0.0"
   test: ">=0.12.30 <2.0.0"


### PR DESCRIPTION
# Summary
Clean up some lint warnings by using `=` instead of `:` for default values

# Testing
 - Code review & CI passing is sufficient