### PR TITLE
Release font_face_observer 2.0.10

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'font_face_observer'
-version: 2.0.9
+version: 2.0.10
 description: Font load events, simple, small and efficient. Dart port of https://github.com/bramstein/fontfaceobserver
 author: Rob Becker <rob.becker@workiva.com>
 homepage: https://github.com/Workiva/font_face_observer


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Use = instead of : for default values](https://github.com/Workiva/font_face_observer/pull/46)


Requested by: @Merge of https://github.com/Workiva/font_face_observer/pull/46

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/font_face_observer/compare/2.0.9...Workiva:release_font_face_observer_2.0.10
Diff Between Last Tag and New Tag: https://github.com/Workiva/font_face_observer/compare/2.0.9...2.0.10

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5580661601861632/logs/)