### PR TITLE
Migrate to null safety

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ addons:
 
 jobs:
   include:
-    - dart: 2.4.0
-      name: "SDK: 2.4.0"
-      script:
-        - dartanalyzer .
-        - pub run test
     - dart: stable
       name: "SDK: stable"
       script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/dart2_base_image:1 as build
+FROM google/dart:2
 WORKDIR /build/
 ADD pubspec.yaml /build
 RUN pub get && pub run test --no-chain-stack-traces -p vm -p chrome --reporter=expanded

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM drydock-prod.workiva.net/workiva/dart2_base_image:1 as build
 WORKDIR /build/
 ADD pubspec.yaml /build
-RUN pub get
+RUN pub get && pub run test --no-chain-stack-traces -p vm -p chrome --reporter=expanded
 FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM google/dart:2
 WORKDIR /build/
 ADD pubspec.yaml /build
-RUN pub get && pub run test --no-chain-stack-traces -p vm -p chrome --reporter=expanded
+RUN pub get
 FROM scratch

--- a/example/main.dart
+++ b/example/main.dart
@@ -76,8 +76,8 @@ class _FontConfig {
   bool useSimulatedLoadEvents;
   bool expectLoad;
   _FontConfig(
-      {this.family,
-      this.url,
+      {required this.family,
+      required this.url,
       this.testString = _successMessage,
       this.expectLoad = true,
       this.useSimulatedLoadEvents = false});
@@ -136,7 +136,7 @@ void _drawTextToCanvas(String text, String fontName, CanvasElement canvas) {
   // ignore: avoid_as
   canvas.getContext('2d') as CanvasRenderingContext2D
     ..setFillColorRgb(255, 255, 255)
-    ..fillRect(0, 0, canvas.width, canvas.height)
+    ..fillRect(0, 0, canvas.width!, canvas.height!)
     ..setFillColorRgb(0, 0, 0)
     ..font = '18px $fontName'
     ..fillText(text, 5, 28);
@@ -148,7 +148,7 @@ supportsStretch: $supportsStretch
 supportsNativeFontLoading: $supportsNativeFontLoading
 hasWebKitFallbackBug: $hasWebkitFallbackBug
   ''';
-  document.getElementById('supports').text = supportString;
+  document.getElementById('supports')!.text = supportString;
   print(supportString);
 }
 
@@ -163,7 +163,7 @@ Future<Null> _loadFont(_FontConfig cfg, bool useSimulatedLoadEvents) async {
   print('  * $result');
   final String message = cfg.testString;
 
-  final Element table = document.getElementById('table');
+  final Element table = document.getElementById('table')!;
 
   final CanvasElement canvas = CanvasElement()
     ..width = 400

--- a/example/unload.dart
+++ b/example/unload.dart
@@ -76,24 +76,25 @@ _FontConfig _cfg3 =
 _FontConfig _cfg4 =
     _FontConfig(family: 'Roboto_2', url: '/fonts/Roboto.ttf', group: _groupB);
 
-Element _unloadButton = document.getElementById('unloadBtn');
-Element _unloadGroupButton = document.getElementById('unloadGroupBtn');
-Element _unloadGroupButtonB = document.getElementById('unloadGroupBtnB');
-Element _loadButton = document.getElementById('loadBtn');
-Element _asyncBtn = document.getElementById('asyncBtn');
+Element _unloadButton = document.getElementById('unloadBtn')!;
+Element _unloadGroupButton = document.getElementById('unloadGroupBtn')!;
+Element _unloadGroupButtonB = document.getElementById('unloadGroupBtnB')!;
+Element _loadButton = document.getElementById('loadBtn')!;
+Element _asyncBtn = document.getElementById('asyncBtn')!;
 
 class _FontConfig {
+  String key;
   String url;
   String family;
   String group;
   bool useSimulatedLoadEvents;
-  bool expectLoad;
+
   _FontConfig(
-      {this.family,
-      this.url,
+      {required this.family,
+      required this.url,
       this.useSimulatedLoadEvents = false,
-      this.group = FontFaceObserver.defaultGroup});
-  String key;
+      this.group = FontFaceObserver.defaultGroup,
+      this.key = ''});
 }
 
 Future<FontLoadResult> _loadFont(_FontConfig cfg) async {
@@ -126,14 +127,14 @@ Future<Null> _load(Event _) async {
 
 void _updateCounts() {
   int n = querySelectorAll('._ffo_temp').length;
-  document.getElementById('ffo_temp_elements').innerHtml = n.toString();
+  document.getElementById('ffo_temp_elements')!.innerHtml = n.toString();
 
   n = querySelectorAll('style._ffo').length;
-  document.getElementById('ffo_elements').innerHtml = n.toString();
+  document.getElementById('ffo_elements')!.innerHtml = n.toString();
 
-  document.getElementById('ffo_keys').innerHtml =
+  document.getElementById('ffo_keys')!.innerHtml =
       FontFaceObserver.getLoadedFontKeys().toString();
-  document.getElementById('ffo_groups').innerHtml =
+  document.getElementById('ffo_groups')!.innerHtml =
       FontFaceObserver.getLoadedGroups().toString();
 }
 

--- a/lib/data_uri.dart
+++ b/lib/data_uri.dart
@@ -78,10 +78,10 @@ import 'dart:typed_data';
 ///
 /// Example Usage:
 /// ```
-/// DataUri di = new DataUri();
-///   ..data = DataUri.base64EncodeString('test');
-///   ..mimeType = 'text/plain';
-///   ..encoding = 'utf-8';
+/// DataUri di = new DataUri(
+///   data: DataUri.base64EncodeString('test');
+///   mimeType: 'text/plain';
+///   encoding: 'utf-8');
 /// di.toString(); # data:text/plain;charset=utf-8;base64,dGVzdA==
 /// ```
 
@@ -102,13 +102,13 @@ class DataUri {
   /// [isDataBase64Encoded] is passed in as false
   DataUri(
       {this.mimeType = 'application/octet-stream',
-      this.encoding,
-      this.data,
+      this.encoding = '',
+      this.data = '',
       this.isDataBase64Encoded = true});
 
   @override
   String toString() =>
-      'data:${mimeType != null && mimeType.isNotEmpty ? mimeType : ""}${encoding != null && encoding.isNotEmpty ? ";charset=$encoding" : ""}${isDataBase64Encoded ? ";base64" : ""},${data != null ? data : ""}';
+      'data:${mimeType.isNotEmpty ? mimeType : ""}${encoding.isNotEmpty ? ";charset=$encoding" : ""}${isDataBase64Encoded ? ";base64" : ""},${data}';
 
   /// Static method to encode a string to base64
   static String base64EncodeString(String string) => window.btoa(string);

--- a/lib/font_face_observer.dart
+++ b/lib/font_face_observer.dart
@@ -379,9 +379,9 @@ class FontFaceObserver {
       document.body!.append(dummy);
     }
 
-    late Ruler _rulerSansSerif;
-    late Ruler _rulerSerif;
-    late Ruler _rulerMonospace;
+    Ruler? _rulerSansSerif;
+    Ruler? _rulerSerif;
+    Ruler? _rulerMonospace;
 
     // if the browser supports FontFace API set up an interval to check if
     // the font is loaded
@@ -410,9 +410,9 @@ class FontFaceObserver {
 
       // cleanup rulers only if simulating font load events
       if (!isNative) {
-        _rulerSansSerif.dispose();
-        _rulerSerif.dispose();
-        _rulerMonospace.dispose();
+        _rulerSansSerif?.dispose();
+        _rulerSerif?.dispose();
+        _rulerMonospace?.dispose();
       }
 
       return flr;

--- a/lib/font_face_observer.dart
+++ b/lib/font_face_observer.dart
@@ -98,6 +98,8 @@ class _FontRecord {
   Map<String, int> groupUses = <String, int>{};
   Future<FontLoadResult> futureLoadResult;
 
+  _FontRecord({required this.styleElement, required this.futureLoadResult});
+
   int get uses => _uses;
   set uses(int newUses) {
     _uses = newUses;
@@ -105,40 +107,40 @@ class _FontRecord {
   }
 
   int incrementGroupCount(String group) {
-    if (_isNullOrWhitespace(group)) {
-      return groupUses[group];
+    if (_isWhitespace(group)) {
+      return 0;
     }
     if (groupUses.containsKey(group)) {
-      groupUses[group]++;
+      groupUses[group] = (groupUses[group] ?? 0) + 1;
     } else {
       groupUses[group] = 1;
     }
     _updateGroupUseCounts();
-    return groupUses[group];
+    return groupUses[group] ?? 0;
   }
 
   int decrementGroupCount(String group) {
-    if (_isNullOrWhitespace(group)) {
-      return groupUses[group];
+    if (_isWhitespace(group)) {
+      return 0;
     }
     if (groupUses.containsKey(group)) {
-      groupUses[group]--;
-      if (groupUses[group] <= 0) {
+      groupUses[group] = (groupUses[group] ?? 0) - 1;
+      if (groupUses[group]! <= 0) {
         groupUses.remove(group);
       }
     } else {
       groupUses.remove(group);
     }
     _updateGroupUseCounts();
-    return groupUses[group];
+    return groupUses[group] ?? 0;
   }
 
   bool isInGroup(String group) {
-    if (_isNullOrWhitespace(group)) {
+    if (_isWhitespace(group)) {
       return false;
     }
     if (groupUses.containsKey(group)) {
-      return groupUses[group] > 0;
+      return (groupUses[group] ?? 0) > 0;
     }
     return false;
   }
@@ -155,7 +157,7 @@ class _FontRecord {
       groupUses.clear();
     }
     final StringBuffer groupData = StringBuffer();
-    for (String group in groupUses.keys) {
+    for (final group in groupUses.keys) {
       groupData.write('$group(${groupUses[group]}) ');
     }
     styleElement.dataset['groups'] = groupData.toString();
@@ -198,9 +200,9 @@ class FontFaceObserver {
   /// The completer representing the load status of this font
   final Completer<FontLoadResult> _result = Completer<FontLoadResult>();
 
-  Ruler _rulerSansSerif;
-  Ruler _rulerSerif;
-  Ruler _rulerMonospace;
+  late Ruler _rulerSansSerif;
+  late Ruler _rulerSerif;
+  late Ruler _rulerMonospace;
 
   /// Construct a new FontFaceObserver. The CSS font family name is the only
   /// required parameter.
@@ -222,20 +224,20 @@ class FontFaceObserver {
       String testString = _defaultTestString,
       this.timeout = _defaultTimeout,
       this.useSimulatedLoadEvents = false,
-      String group = defaultGroup}) {
+      String group = defaultGroup})
+      : _testString =
+            _isWhitespace(testString) ? _defaultTestString : testString,
+        _group = _isWhitespace(group) ? defaultGroup : group {
     if (key != adobeBlankKey && !_loadedFonts.containsKey(adobeBlankKey)) {
       _adobeBlankLoadedFuture = _loadAdobeBlank();
     }
-    this.testString = testString;
-    _group = _isNullOrWhitespace(group) ? defaultGroup : group;
-    if (family != null) {
-      family = family.trim();
-      final bool hasStartQuote =
-          family.startsWith('"') || family.startsWith("'");
-      final bool hasEndQuote = family.endsWith('"') || family.endsWith("'");
-      if (hasStartQuote && hasEndQuote) {
-        family = family.substring(1, family.length - 1);
-      }
+
+    _group = _isWhitespace(group) ? defaultGroup : group;
+    family = family.trim();
+    final bool hasStartQuote = family.startsWith('"') || family.startsWith("'");
+    final bool hasEndQuote = family.endsWith('"') || family.endsWith("'");
+    if (hasStartQuote && hasEndQuote) {
+      family = family.substring(1, family.length - 1);
     }
   }
 
@@ -259,7 +261,7 @@ class FontFaceObserver {
     final Set<String> loadedGroups = Set<String>();
 
     void getLoadedGroups(String k) {
-      final _FontRecord record = _loadedFonts[k];
+      final _FontRecord record = _loadedFonts[k]!;
       loadedGroups.addAll(record.groupUses.keys);
     }
 
@@ -278,7 +280,7 @@ class FontFaceObserver {
   /// A [group] of null or only whitespace is invalid and will return zero
   static Future<int> unloadGroup(String group) async {
     // do nothing if no group is passed in
-    if (_isNullOrWhitespace(group)) {
+    if (_isWhitespace(group)) {
       return 0;
     }
 
@@ -287,7 +289,7 @@ class FontFaceObserver {
     final List<String> keysToRemove = <String>[];
     final List<_FontRecord> records = <_FontRecord>[];
     for (String k in _loadedFonts.keys.toList()) {
-      final _FontRecord record = _loadedFonts[k];
+      final _FontRecord record = _loadedFonts[k]!;
       // wait for the load future to complete
       await record.futureLoadResult;
 
@@ -317,7 +319,7 @@ class FontFaceObserver {
   /// key/group combo was not found.
   static Future<bool> unload(String key, String group) async {
     if (_loadedFonts.containsKey(key)) {
-      final _FontRecord record = _loadedFonts[key];
+      final _FontRecord record = _loadedFonts[key]!;
       // wait for the load future to complete
       await record.futureLoadResult;
 
@@ -346,7 +348,7 @@ class FontFaceObserver {
   /// will be used.
   set testString(String newTestString) {
     _testString =
-        _isNullOrWhitespace(newTestString) ? _defaultTestString : newTestString;
+        _isWhitespace(newTestString) ? _defaultTestString : newTestString;
   }
 
   /// Wait for the font face represented by this FontFaceObserver to become
@@ -359,7 +361,7 @@ class FontFaceObserver {
       return _result.future;
     }
 
-    final _FontRecord record = _loadedFonts[key];
+    final record = _loadedFonts[key];
     if (record == null) {
       return FontLoadResult(isLoaded: false, didTimeout: false);
     }
@@ -371,19 +373,20 @@ class FontFaceObserver {
     // Since browsers may not load a font until it is actually used (lazily loaded)
     // We add this span to trigger the browser to load the font when used
     final String _key = '_ffo_dummy_${key}';
-    Element dummy = document.getElementById(_key);
+    var dummy = document.getElementById(_key);
     if (dummy == null) {
       dummy = SpanElement()
         ..className = '$fontFaceObserverTempClassname _ffo_dummy'
         ..id = _key
         ..setAttribute('style', 'font-family: "${family}"; visibility: hidden;')
         ..text = testString;
-      document.body.append(dummy);
+      document.body!.append(dummy);
     }
 
     // if the browser supports FontFace API set up an interval to check if
     // the font is loaded
-    if (supportsNativeFontLoading && !useSimulatedLoadEvents) {
+    final isNative = supportsNativeFontLoading && !useSimulatedLoadEvents;
+    if (isNative) {
       t = Timer.periodic(
           const Duration(milliseconds: _nativeFontLoadingCheckInterval),
           _periodicallyCheckDocumentFonts);
@@ -396,11 +399,18 @@ class FontFaceObserver {
     Timer(Duration(milliseconds: timeout), () => _onTimeout(t));
 
     return _result.future.then((FontLoadResult flr) {
-      if (t != null && t.isActive) {
+      if (t.isActive) {
         t.cancel();
       }
-      dummy.remove();
-      _cleanupAfterCheck();
+      dummy?.remove();
+
+      // cleanup rulers only if simulating font load events
+      if (!isNative) {
+        _rulerSansSerif.dispose();
+        _rulerSerif.dispose();
+        _rulerMonospace.dispose();
+      }
+
       return flr;
     });
   }
@@ -408,7 +418,7 @@ class FontFaceObserver {
   /// Load the font into the browser given a url that could be a network url
   /// or a pre-built data or blob url.
   Future<FontLoadResult> load(String url) async {
-    final _FontRecord record = _load(url);
+    final record = _load(url);
     if (_result.isCompleted) {
       return _result.future;
     }
@@ -437,9 +447,9 @@ class FontFaceObserver {
   _FontRecord _load(String url) {
     StyleElement styleElement;
     final String _key = key;
-    _FontRecord record;
-    if (_loadedFonts.containsKey(_key)) {
-      record = _loadedFonts[_key];
+    late _FontRecord record;
+    if (_loadedFonts.containsKey(_key) && _loadedFonts[_key] != null) {
+      record = _loadedFonts[_key]!;
     } else {
       final String rule = '''
       @font-face {
@@ -454,12 +464,11 @@ class FontFaceObserver {
         ..text = rule
         ..dataset['key'] = _key;
 
-      record = _FontRecord()
-        ..styleElement = styleElement
-        ..futureLoadResult = _result.future;
+      record = _FontRecord(
+          styleElement: styleElement, futureLoadResult: _result.future);
 
       _loadedFonts[_key] = record;
-      document.head.append(styleElement);
+      document.head!.append(styleElement);
     }
     record.incrementGroupCount(group);
     return record;
@@ -476,7 +485,7 @@ class FontFaceObserver {
   /// It will cancel the passed in Timer if it is still active and
   /// complete the result with a timed out FontLoadResult
   void _onTimeout(Timer t) {
-    if (t != null && t.isActive) {
+    if (t.isActive) {
       t.cancel();
     }
     if (!_result.isCompleted) {
@@ -488,7 +497,7 @@ class FontFaceObserver {
   /// built in Font Face API. If it is loaded, the passed in Timer [t] will
   /// be cancelled. If the font is not loaded, this is a no-op.
   void _periodicallyCheckDocumentFonts(Timer t) {
-    if (document.fonts.check(_getStyle('"$family"'), testString)) {
+    if (document.fonts!.check(_getStyle('"$family"'), testString)) {
       t.cancel();
       _result.complete(FontLoadResult(isLoaded: true, didTimeout: false));
     }
@@ -553,9 +562,7 @@ class FontFaceObserver {
               return;
             }
           }
-          if (container != null) {
-            container.remove();
-          }
+          container.remove();
           if (!_result.isCompleted) {
             _result.complete(FontLoadResult(isLoaded: true, didTimeout: false));
           }
@@ -577,7 +584,7 @@ class FontFaceObserver {
       ..append(_rulerSerif.element)
       ..append(_rulerMonospace.element);
 
-    document.body.append(container);
+    document.body!.append(container);
 
     fallbackWidthSansSerif = _rulerSansSerif.getWidth();
     fallbackWidthSerif = _rulerSerif.getWidth();
@@ -608,16 +615,10 @@ class FontFaceObserver {
     // but if the document is hidden, it may not, so we will periodically
     // check for changes in the rulers if the document is hidden
     return Timer.periodic(const Duration(milliseconds: 50), (Timer t) {
-      if (document.hidden) {
-        if (_rulerSansSerif != null) {
-          widthSansSerif = _rulerSansSerif.getWidth();
-        }
-        if (_rulerSerif != null) {
-          widthSerif = _rulerSerif.getWidth();
-        }
-        if (_rulerMonospace != null) {
-          widthMonospace = _rulerMonospace.getWidth();
-        }
+      if (document.hidden!) {
+        widthSansSerif = _rulerSansSerif.getWidth();
+        widthSerif = _rulerSerif.getWidth();
+        widthMonospace = _rulerMonospace.getWidth();
         _checkWidths();
       }
     });
@@ -629,15 +630,6 @@ class FontFaceObserver {
     record.styleElement.remove();
     _loadedFonts.remove(key);
   }
-
-  void _cleanupAfterCheck() {
-    _rulerSansSerif?.dispose();
-    _rulerSerif?.dispose();
-    _rulerMonospace?.dispose();
-    _rulerSansSerif = null;
-    _rulerSerif = null;
-    _rulerMonospace = null;
-  }
 }
 
-bool _isNullOrWhitespace(String s) => s == null || s.trim().isEmpty;
+bool _isWhitespace(String s) => s.trim().isEmpty;

--- a/lib/font_face_observer.dart
+++ b/lib/font_face_observer.dart
@@ -394,7 +394,8 @@ class FontFaceObserver {
       _rulerSansSerif = Ruler(testString);
       _rulerSerif = Ruler(testString);
       _rulerMonospace = Ruler(testString);
-      t = _simulateFontLoadEvents(_rulerSansSerif, _rulerSerif, _rulerMonospace);
+      t = _simulateFontLoadEvents(
+          _rulerSansSerif, _rulerSerif, _rulerMonospace);
     }
 
     // Start a timeout timer that will cancel everything and complete
@@ -512,7 +513,8 @@ class FontFaceObserver {
   /// dimensions of the test string change. These rulers are checked periodically
   /// waiting for the font to become available. The Timer is returned so it may
   /// be cancelled and not check infinitely.
-  Timer _simulateFontLoadEvents(Ruler _rulerSansSerif, Ruler _rulerSerif, Ruler _rulerMonospace) {
+  Timer _simulateFontLoadEvents(
+      Ruler _rulerSansSerif, Ruler _rulerSerif, Ruler _rulerMonospace) {
     num widthSansSerif = -1;
     num widthSerif = -1;
     num widthMonospace = -1;

--- a/lib/font_face_observer.dart
+++ b/lib/font_face_observer.dart
@@ -200,10 +200,6 @@ class FontFaceObserver {
   /// The completer representing the load status of this font
   final Completer<FontLoadResult> _result = Completer<FontLoadResult>();
 
-  late Ruler _rulerSansSerif;
-  late Ruler _rulerSerif;
-  late Ruler _rulerMonospace;
-
   /// Construct a new FontFaceObserver. The CSS font family name is the only
   /// required parameter.
   ///
@@ -383,6 +379,10 @@ class FontFaceObserver {
       document.body!.append(dummy);
     }
 
+    late Ruler _rulerSansSerif;
+    late Ruler _rulerSerif;
+    late Ruler _rulerMonospace;
+
     // if the browser supports FontFace API set up an interval to check if
     // the font is loaded
     final isNative = supportsNativeFontLoading && !useSimulatedLoadEvents;
@@ -391,7 +391,10 @@ class FontFaceObserver {
           const Duration(milliseconds: _nativeFontLoadingCheckInterval),
           _periodicallyCheckDocumentFonts);
     } else {
-      t = _simulateFontLoadEvents();
+      _rulerSansSerif = Ruler(testString);
+      _rulerSerif = Ruler(testString);
+      _rulerMonospace = Ruler(testString);
+      t = _simulateFontLoadEvents(_rulerSansSerif, _rulerSerif, _rulerMonospace);
     }
 
     // Start a timeout timer that will cancel everything and complete
@@ -509,11 +512,7 @@ class FontFaceObserver {
   /// dimensions of the test string change. These rulers are checked periodically
   /// waiting for the font to become available. The Timer is returned so it may
   /// be cancelled and not check infinitely.
-  Timer _simulateFontLoadEvents() {
-    _rulerSansSerif = Ruler(testString);
-    _rulerSerif = Ruler(testString);
-    _rulerMonospace = Ruler(testString);
-
+  Timer _simulateFontLoadEvents(Ruler _rulerSansSerif, Ruler _rulerSerif, Ruler _rulerMonospace) {
     num widthSansSerif = -1;
     num widthSerif = -1;
     num widthMonospace = -1;

--- a/lib/src/ruler.dart
+++ b/lib/src/ruler.dart
@@ -74,11 +74,11 @@ const String fontFaceObserverTempClassname = '_ffo_temp';
 /// a font being loaded.
 class Ruler {
   /// The element in the DOM that this ruler is using to measure
-  Element element;
-  SpanElement _collapsible;
-  SpanElement _expandable;
-  SpanElement _collapsibleInner;
-  SpanElement _expandableInner;
+  late Element element;
+  late SpanElement _collapsible;
+  late SpanElement _expandable;
+  late SpanElement _collapsibleInner;
+  late SpanElement _expandableInner;
   int _lastOffsetWidth = -1;
 
   /// The test string to use when measuring
@@ -199,18 +199,11 @@ class Ruler {
       ss.cancel();
     }
     _subscriptions.clear();
-    _subscriptions = null;
 
-    element?.remove();
-    _collapsible?.remove();
-    _expandable?.remove();
-    _collapsibleInner?.remove();
-    _expandableInner?.remove();
-
-    element = null;
-    _collapsible = null;
-    _expandable = null;
-    _collapsibleInner = null;
-    _expandableInner = null;
+    element.remove();
+    _collapsible.remove();
+    _expandable.remove();
+    _collapsibleInner.remove();
+    _expandableInner.remove();
   }
 }

--- a/lib/support.dart
+++ b/lib/support.dart
@@ -99,7 +99,7 @@ bool _supportsNativeFontLoading() {
     // it is supported. If there is an exception, then it is not supported.
 
     // ignore: unnecessary_statements
-    document.fonts.status;
+    document.fonts!.status;
   } catch (_) {
     supports = false;
   }
@@ -111,14 +111,11 @@ bool _supportsNativeFontLoading() {
 bool _hasWebKitFallbackBug(String userAgent) {
   final RegExp regex = RegExp('AppleWebKit\/([0-9]+)(?:\.([0-9]+))');
   final Iterable<Match> matches = regex.allMatches(userAgent);
-  if (matches == null || matches.isEmpty) {
+  if (matches.isEmpty) {
     return false;
   }
   final Match match = matches.first;
-  if (match == null) {
-    return false;
-  }
-  final num major = int.parse(match.group(1));
-  final num minor = int.parse(match.group(2));
+  final num major = int.parse(match.group(1)!);
+  final num minor = int.parse(match.group(2)!);
   return major < 536 || (major == 536 && minor <= 11);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,15 @@
 name: font_face_observer
-version: 3.0.0-nullsafety.0
+version: 3.0.0
 description: Font load events, simple, small and efficient. Dart port of https://github.com/bramstein/fontfaceobserver
 author: Rob Becker <rob.becker@workiva.com>
 homepage: https://github.com/Workiva/font_face_observer
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
   build_runner: ^1.7.1
-  build_test: ^0.10.9
+  build_test: ^2.0.0
   build_web_compilers: ^2.5.1
-  test: 1.16.0-nullsafety.13
+  test: ^1.16.8
   workiva_analysis_options: ^1.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,15 @@
 name: font_face_observer
-version: 2.0.13
+version: 3.0.0-nullsafety.0
 description: Font load events, simple, small and efficient. Dart port of https://github.com/bramstein/fontfaceobserver
 author: Rob Becker <rob.becker@workiva.com>
 homepage: https://github.com/Workiva/font_face_observer
 
 environment:
-  sdk: '>=2.4.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dev_dependencies:
   build_runner: ^1.7.1
   build_test: ^0.10.9
   build_web_compilers: ^2.5.1
-  test: ^1.9.1
+  test: 1.16.0-nullsafety.13
   workiva_analysis_options: ^1.0.1

--- a/test/data_uri_test.dart
+++ b/test/data_uri_test.dart
@@ -85,15 +85,9 @@ void main() {
           equals('data:text/plain;charset=utf-8;base64,AAAAAAAAAAA='));
 
       di
-        ..data = null
-        ..encoding = null
-        ..isDataBase64Encoded = false
-        ..mimeType = null;
-      expect(di.toString(), equals('data:,'));
-
-      di
         ..data = ''
         ..encoding = ''
+        ..isDataBase64Encoded = false
         ..mimeType = '';
       expect(di.toString(), equals('data:,'));
     });

--- a/test/font_face_observer_test.dart
+++ b/test/font_face_observer_test.dart
@@ -170,7 +170,7 @@ void main() {
           .load(_FontUrls.roboto);
 
       // AdobeBlank is always loaded, so expect that too
-      final Iterable<String> keys = FontFaceObserver.getLoadedFontKeys();
+      final keys = FontFaceObserver.getLoadedFontKeys();
       expect(keys.length, equals(5));
       expect(keys.contains('font_keys1_normal_normal_normal'), isTrue);
       expect(keys.contains('font_keys2_normal_normal_normal'), isTrue);
@@ -179,7 +179,7 @@ void main() {
       expect(keys.contains(adobeBlankKey), isTrue);
 
       // expect the default group too
-      final Iterable<String> groups = FontFaceObserver.getLoadedGroups();
+      final groups = FontFaceObserver.getLoadedGroups();
       expect(groups.length, equals(4));
       expect(groups.contains(FontFaceObserver.defaultGroup), isTrue);
       expect(groups.contains('group_1'), isTrue);
@@ -207,7 +207,7 @@ void main() {
       final FontLoadResult result = await ffo.load(_FontUrls.roboto);
       expect(result.isLoaded, isTrue);
       await FontFaceObserver.unload(key, ffo.group);
-      final Element styleElement = querySelector('style[data-key="${key}"]');
+      final styleElement = querySelector('style[data-key="${key}"]');
       expect(styleElement, isNull);
     });
 
@@ -232,7 +232,7 @@ void main() {
       final String key = ffo.key;
       FontLoadResult result = await ffo.load(_FontUrls.roboto);
       expect(result.isLoaded, isTrue);
-      final Element styleElement = querySelector('style[data-key="${key}"]');
+      final Element styleElement = querySelector('style[data-key="${key}"]')!;
       expect(styleElement.dataset['uses'], '1');
 
       // load it again with the same group, uses should be 2

--- a/test/ruler_test.dart
+++ b/test/ruler_test.dart
@@ -70,18 +70,17 @@ import 'package:font_face_observer/src/ruler.dart';
 const int _startWidth = 100;
 
 void main() {
-  Ruler ruler;
+  late Ruler ruler;
 
   setUp(() {
     ruler = Ruler('hello')
       ..setFont('')
       ..setWidth(_startWidth);
-    document.body.append(ruler.element);
+    document.body!.append(ruler.element);
   });
 
   tearDown(() {
     ruler.element.remove();
-    ruler = null;
   });
 
   Future<Null> testResize(num width1) async {


### PR DESCRIPTION
Converted to null safety via the migration tool and then heavy manual fixes.
This ups the minimum Dart to 2.12.