### PR TITLE
Add basic skynet.yaml

### DIFF
--- a/skynet.yaml
+++ b/skynet.yaml
@@ -1,0 +1,10 @@
+description: basic skynet
+contact: "#dart-lang"
+image: drydock.workiva.net/workiva/skynet-images:bash_curl_alpinelatest-latest
+size: small
+timeout: short
+run:
+  on-tag: true
+  on-pull-request: true
+scripts:
+  - echo "No tests currently set"


### PR DESCRIPTION
This PR adds a basic skynet.yaml. This repo has silently stopped being able to release since the passing skynet result was enforced in order to release. This unblocks being able to release and publishing a dart package.

For more info, reach out to `#support-frontend-architecture` on Slack.