### PR TITLE
Release font_face_observer 3.1.10

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: font_face_observer
-version: 3.1.9
+version: 3.1.10
 description: Font load events, simple, small and efficient. Dart port of https://github.com/bramstein/fontfaceobserver
 homepage: https://github.com/Workiva/font_face_observer
 


### PR DESCRIPTION


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/font_face_observer/compare/3.1.9...Workiva:release_font_face_observer_3.1.10
Diff Between Last Tag and New Tag: https://github.com/Workiva/font_face_observer/compare/3.1.9...3.1.10

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5432637706469376/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5432637706469376/?repo_name=Workiva%2Ffont_face_observer&pull_number=72)