### PR TITLE
Allow analyzer 10

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -77,6 +77,7 @@ class _FontConfig {
       {required this.family,
       required this.url,
       this.testString = _successMessage,
+      // ignore: unused_element_parameter
       this.expectLoad = true});
 }
 

--- a/example/unload.dart
+++ b/example/unload.dart
@@ -91,6 +91,7 @@ class _FontConfig {
       {required this.family,
       required this.url,
       this.group = FontFaceObserver.defaultGroup,
+      // ignore: unused_element_parameter
       this.key = ''});
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dev_dependencies:
   build_runner: ^2.0.0
-  build_test: ^2.0.0
+  build_test: '>=2.0.0 <4.0.0'
   build_web_compilers: '>=3.0.0 <5.0.0'
   test: ^1.16.8
   workiva_analysis_options: ^1.0.1


### PR DESCRIPTION
# Changes
Updates the range for build_test to '>=2.0.0 <4.0.0' in order to be able to resolve to analyzer 10.
Added 2 ignore comments for warnings about unused parameters for internal classes, but I didn't want to change any APIs in this PR, so just ignored them so analysis passes.

# QA
- CI passes
- resolves to analyzer 10 on Dart stable